### PR TITLE
Add nokogiri dependency and update Gemfile.lock to >= 1.18.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "jekyll-theme-chirpy", "~> 6.2", ">= 6.2.3"
+gem "nokogiri", ">= 1.18.9"
 
 group :test do
   gem "html-proofer", "~> 4.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,9 +76,9 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.15.4-x64-mingw-ucrt)
+    nokogiri (1.18.9-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
+    nokogiri (1.18.9-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
     pathutil (0.16.2)
@@ -119,6 +119,7 @@ DEPENDENCIES
   http_parser.rb (~> 0.6.0)
   jekyll-redirect-from
   jekyll-theme-chirpy (~> 6.2, >= 6.2.3)
+  nokogiri (>= 1.18.9)
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1.1)


### PR DESCRIPTION
### Motivation
- Ensure the project depends directly on a safe Nokogiri release by adding an explicit constraint `>= 1.18.9` to address security concerns and make the intent explicit in the Gemfile.
- Keep the lockfile consistent with the intended safe version so CI and downstream installs will use the expected Nokogiri platforms and versions.

### Description
- Added `gem "nokogiri", ">= 1.18.9"` to `Gemfile` alongside other top-level gems.
- Updated `Gemfile.lock` to pin the Nokogiri platform entries to `1.18.9` for `x64-mingw-ucrt` and `x86_64-linux` and added the `nokogiri (>= 1.18.9)` dependency entry under `DEPENDENCIES`.
- Staged and committed the changes to `Gemfile` and `Gemfile.lock`.

### Testing
- Ran `bundle update nokogiri`, which failed due to a `403 Forbidden` from `rubygems.org` and therefore Bundler could not regenerate the lockfile automatically.
- Ran `BUNDLE_FULL_INDEX=true bundle update nokogiri`, which also failed with the same `403 Forbidden` from `rubygems.org`.
- Verified the repository files by inspecting `Gemfile` and `Gemfile.lock` to confirm the `nokogiri` dependency and the updated platform entries were present (file checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f5fcb7e8832a87a0419638443252)