### PR TITLE
Remove Windows Nokogiri platform from lockfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "jekyll-theme-chirpy", "~> 6.2", ">= 6.2.3"
-gem "nokogiri", ">= 1.18.9"
+gem "nokogiri", ">= 1.18.10"
 
 group :test do
   gem "html-proofer", "~> 4.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,9 +12,7 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     ffi (1.16.3)
-    ffi (1.16.3-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
-    google-protobuf (3.24.4-x64-mingw-ucrt)
     google-protobuf (3.24.4-x86_64-linux)
     html-proofer (4.4.3)
       addressable (~> 2.3)
@@ -76,9 +74,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.18.9-x64-mingw-ucrt)
-      racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-linux)
+    nokogiri (1.18.10-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
     pathutil (0.16.2)
@@ -92,8 +88,6 @@ GEM
     rexml (3.2.6)
     rouge (4.1.3)
     safe_yaml (1.0.5)
-    sass-embedded (1.69.4-x64-mingw-ucrt)
-      google-protobuf (~> 3.23)
     sass-embedded (1.69.4-x86_64-linux-gnu)
       google-protobuf (~> 3.23)
     terminal-table (3.0.2)
@@ -111,7 +105,6 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
@@ -119,7 +112,7 @@ DEPENDENCIES
   http_parser.rb (~> 0.6.0)
   jekyll-redirect-from
   jekyll-theme-chirpy (~> 6.2, >= 6.2.3)
-  nokogiri (>= 1.18.9)
+  nokogiri (>= 1.18.10)
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1.1)


### PR DESCRIPTION
### Motivation
- CI was failing because the lockfile referenced a removed Windows-specific Nokogiri build, causing `bundle install` to error in GitHub Actions. 
- The Gemfile was previously updated to require `nokogiri (>= 1.18.10)`, so the lockfile should be aligned to a resolvable platform build.

### Description
- Removed the `x64-mingw-ucrt` platform entries from `Gemfile.lock` so only the `x86_64-linux` platform remains. 
- Replaced the Windows-specific `nokogiri` entry with the Linux build `nokogiri (1.18.10-x86_64-linux)` and updated the `DEPENDENCIES` line to `nokogiri (>= 1.18.10)`. 
- Dropped other Windows platform-specific gem entries (such as `ffi`, `google-protobuf`, and `sass-embedded`) from the lockfile to avoid referencing removed platform builds.

### Testing
- Attempted dependency resolution via `bundle install` in the CI-like environment, but it failed because `rubygems.org` returned HTTP 403 and the removed Windows gem could not be fetched. 
- No further automated tests were run in this environment due to the network/repository access error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a020b76f8832abd3dffc4805ced38)